### PR TITLE
Minor fixes for year 2017

### DIFF
--- a/Microsoft.Dx.Wopi/Security/WopiProof.cs
+++ b/Microsoft.Dx.Wopi/Security/WopiProof.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Dx.Wopi.Security
                 try
                 {
                     rsaProvider.ImportCspBlob(Convert.FromBase64String(proofFromDiscovery));
-                    return rsaProvider.VerifyData(expectedProof, "SHA256", Convert.FromBase64String(proofFromRequest));
+                    return rsaProvider.VerifyData(expectedProof, new SHA256CryptoServiceProvider(), Convert.FromBase64String(proofFromRequest));
                 }
                 catch (FormatException)
                 {

--- a/Microsoft.Dx.Wopi/WopiDiscovery.cs
+++ b/Microsoft.Dx.Wopi/WopiDiscovery.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Dx.Wopi
             public static List<string> Placeholders = new List<string>() { BUSINESS_USER,
             DC_LLCC, DISABLE_ASYNC, DISABLE_CHAT, DISABLE_BROADCAST,
             EMBDDED, FULLSCREEN, PERFSTATS, RECORDING, THEME_ID, UI_LLCC,
-            VALIDATOR_TEST_CATEGORY
+            VALIDATOR_TEST_CATEGORY, HOST_SESSION_ID
         };
             public const string BUSINESS_USER = "<IsLicensedUser=BUSINESS_USER&>";
             public const string DC_LLCC = "<rs=DC_LLCC&>";
@@ -37,6 +37,7 @@ namespace Microsoft.Dx.Wopi
             public const string THEME_ID = "<thm=THEME_ID&>";
             public const string UI_LLCC = "<ui=UI_LLCC&>";
             public const string VALIDATOR_TEST_CATEGORY = "<testcategory=VALIDATOR_TEST_CATEGORY>";
+            public const string HOST_SESSION_ID = "<hid=HOST_SESSION_ID&>";
 
             /// <summary>
             /// Sets a specific WOPI URL placeholder with the correct value
@@ -72,6 +73,9 @@ namespace Microsoft.Dx.Wopi
                         break;
                     case VALIDATOR_TEST_CATEGORY:
                         result = ph + "OfficeOnline"; //This value can be set to All, OfficeOnline or OfficeNativeClient to activate tests specific to Office Online and Office for iOS. If omitted, the default value is All.  
+                        break;
+                    case HOST_SESSION_ID:
+                        result = "";
                         break;
                     default:
                         result = "";


### PR DESCRIPTION
Thank you for a great example!
For those who might want to also use the framework..

First fix: use FIPS-compliant SHA256 provider. Non-FIPS-compliant ("SHA256") default provider may cause problems in some government organizations (in particular, mine), and changing provider to FIPS-compliant should not hurt.

Second is to add new parameters to URL builder.  These come with some 2017 update. If this patch is not there, and update is installed, the code breaks.